### PR TITLE
[FEAT][CLI] Display help message if no input is provided

### DIFF
--- a/bin/styledown.js
+++ b/bin/styledown.js
@@ -10,28 +10,6 @@ const args = minimist(process.argv.slice(2), {
   boolean: ['inline', 'css', 'js', 'conf', 'quiet'],
   alias: { h: 'help', v: 'version', i: 'inline', o: 'output', q: 'quiet' }
 })
-
-if (args.help) {
-  let cmd = basename(process.argv[1])
-  console.log([
-      'Usage:',
-      `    ${cmd} [options] FILE`,
-      `    ... | ${cmd} [options]`,
-      '',
-      'Options:',
-      '    -h, --help           print usage information',
-      '    -v, --version        show version info and exit',
-      '    -i, --inline         force extracts from inline CSS comments (for piping)',
-      '    -o, --output FILE    write output a file',
-      '',
-      'Support files:',
-      `    ${cmd} --conf > config.md`,
-      `    ${cmd} --css > styledown.css`,
-      `    ${cmd} --js > styledown.js`,
-  ].join('\n'))
-  process.exit()
-}
-
 if (args.version) {
   console.log(version)
   process.exit()
@@ -49,6 +27,26 @@ if (args.css) {
 
 if (args.conf) {
   print(Styledown.defaults.conf())
+  process.exit()
+}
+
+if (args.help || args._.length === 0) {
+  let cmd = basename(process.argv[1])
+  console.log([
+      'Usage:',
+      `    ${cmd} [options] FILE`,
+      '',
+      'Options:',
+      '    -h, --help           print usage information',
+      '    -v, --version        show version info and exit',
+      '    -i, --inline         force extracts from inline CSS comments (for piping)',
+      '    -o, --output FILE    write output a file',
+      '',
+      'Support files:',
+      `    ${cmd} --conf > config.md`,
+      `    ${cmd} --css > styledown.css`,
+      `    ${cmd} --js > styledown.js`,
+  ].join('\n'))
   process.exit()
 }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -42,24 +42,6 @@ describe('CLI:', function() {
     })
   })
 
-  describe('pipe', function() {
-    pipe('### hi\nthere\n')
-    success()
-    it('works', function() {
-      expect(result.out).match(/<h3[^>]*>hi<\/h3>/)
-      expect(result.out).match(/<p[^>]*>there<\/p>/)
-    })
-  })
-
-  describe('pipe --inline', function() {
-    pipe("/**\n * hi:\n * there\n */", ['--inline'])
-    success()
-    it('works', function() {
-      expect(result.out).match(/<h3[^>]*>hi<\/h3>/)
-      expect(result.out).match(/<p[^>]*>there<\/p>/)
-    })
-  })
-
   describe('--output', function() {
     let fname = randomfile()
     run(`test/fixtures/basic/basic-1.md -o ${  fname}`)


### PR DESCRIPTION
Currently when you call `styledown` alone nothin happen the cli wait for inputs in the stdin.
This behavior is disturbing as there's no indications displayed.

Now calling `styledown` alone will print the help message and it's no longer possible to use stdin after a pipe (`|`).
