### PR TITLE
Release Styledownv2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,10 +12,6 @@ Write maintainable CSS styleguides efficiently using a Markdown.
  styledown --help
 ```
 
-[![npm version](http://img.shields.io/npm/v/styledown.svg?style=flat)](https://npmjs.org/package/styledown "View this project on npm")
-
-[example]: http://cdn.rawgit.com/styledown/styledown/v1.0.2/examples/bootstrap/index.html
-
 ## How it works
 
 Styledown is made to work in most web development setups. It doesn't favor any framework or language or any preprocessor.
@@ -69,7 +65,7 @@ files.
 
 .your-component-here {
   display: block;
-  ...
+  /*...*/
 }
 ```
 
@@ -86,8 +82,12 @@ lets you define what will be in the output head/body.
 ### Head
 
     link(rel="stylesheet" href="/assets/application.css")
-    link(rel='stylesheet' href='https://cdn.rawgit.com/styledown/styledown/v1.0.2/data/styledown.css')
-    script(src='https://cdn.rawgit.com/styledown/styledown/v1.0.2/data/styledown.js')
+    <style>
+      /* styledown css */
+    </style>
+    <script>
+      /* styledown js */
+    </script>
 
 ### Body
 
@@ -135,17 +135,3 @@ __Markdown mode:__ Takes Markdown files.
 ## Markup format
 
 Read more: **[Markup format ▸](docs/Format.md)**
-
-## :copyright:
-
-**Styledown** © 2013+, Rico Sta. Cruz. Released under the [MIT License].<br>
-Authored and maintained by Rico Sta. Cruz with help from [contributors].
-
-> [ricostacruz.com](http://ricostacruz.com) &nbsp;&middot;&nbsp;
-> GitHub [@rstacruz](https://github.com/rstacruz) &nbsp;&middot;&nbsp;
-> Twitter [@rstacruz](https://twitter.com/rstacruz)
-
-[MIT License]: http://mit-license.org/
-[contributors]: http://github.com/styledown/styledown/contributors
-[highlight.js]: http://highlightjs.org/
-[Jade]: http://jade-lang.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "styledown",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "css",
     "styleguide"
   ],
-  "version": "1.1.0",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/peopledoc/styledown.git"


### PR DESCRIPTION
## Breaking change

* It's no longer possible to use Styledown after a pipe `|`.  (#22)
* Styledown build for browsers is no longer available. (#20)
* Styledown.js has drop support for ie<9. (#21)

## Feature

* Calling Styledown command alone will now display the help message. (#22)
* It's now possible to use Pug [include](https://pugjs.org/language/includes.html) statement to include external templates at build time. (#19)

## Improvements

* The hide/reveal button has an accessible label now (#21)
* The hide/reveal button hove/focus effect has been improved (#21)
* The highlight colors have been updated to improve color contrast. (#21)
* Styledown JS and CSS are now inlined in the default config.  (#21)
