### PR TITLE
feat(pug): set pug doctype option to html

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,7 +80,8 @@ exports.htmlize = function (src, filePath = '.') {
     return src
   } else {
     return Pug.render(src, {
-      filename: filePath
+      filename: filePath,
+      doctype: 'html'
     })
   }
 }

--- a/test/pug.js
+++ b/test/pug.js
@@ -4,11 +4,12 @@ const template = `
 ### Button
 
     @example
+    img(src="foo.png")
     a.button
       | Hello
 `
 
-describe('jade', function() {
+describe('pug', function() {
   setupTestEnv(this)
 
   beforeEach(function() {
@@ -20,5 +21,10 @@ describe('jade', function() {
   it('example rendering', function() {
     expect(this.$("a.button").length).eql(1)
     expect(this.$("a.button").html()).eql("Hello")
+  })
+
+  it('selfclosing html tag has no "/" at the end', function() {
+    expect(/\/>/.test(this.html)).eql(false)
+    expect(/\/&gt;/.test(this.html)).eql(false)
   })
 })


### PR DESCRIPTION
[PDUI-1413](https://people-doc.atlassian.net/browse/PDUI-1413)

Set pug doctype option to `'html'` to respect [PDUI coding style](https://github.com/peopledoc/peopledoc-ui/blob/master/contributing-docs/HTML-STYLEGUIDE.md#syntax-style) in doc samples.