### PR TITLE
[FIX] Correctly remove trailing slash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -115,7 +115,36 @@ function beautifyHTML(html, options) {
     ...options
   })
 
-  return output.replace(/\/>/g, '>') // Prettier add trailling slash to self-closing elements but we don't want them
+  return removeTrailingSlash(output)
+}
+
+/**
+ * Remove trailing slash on self closing elements but ignore SVG elements
+ * "<input .../>" becomes "<input ...>"
+ * But "<use .../>" is not modified
+ *
+ * @param {string} html
+ */
+
+function removeTrailingSlash(html) {
+
+  const removeSlash = (t) => t.replace(/\/>/g, '>')
+
+  let parts = html
+    .split(/<svg/)
+
+  if (parts.length === 1) {
+    return removeSlash(parts[0])
+  }
+
+  return parts.map((t, i) => {
+    if (i === 0) {
+      return removeSlash(parts[0])
+    }
+    return t.split(/<\/svg>/)
+      .map((t, index) => index % 2 === 1 ? removeSlash(t): t)
+      .join('</svg>')
+    }).join('<svg')
 }
 
 module.exports = {

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,5 +1,5 @@
 const setupTestEnv = require('./setup')
-const { run, pipe, success } = require('./helpers/cli')
+const { run, success } = require('./helpers/cli')
 const {randomfile} = require('./helpers/file')
 const fs = require('fs')
 const { version } = require('../package.json')

--- a/test/pretty_print.js
+++ b/test/pretty_print.js
@@ -1,3 +1,4 @@
+const { beautifyHTML } = require('../lib/utils')
 const setupTestEnv = require('./setup')
 
 describe('Pretty Print', function() {
@@ -9,6 +10,7 @@ describe('Pretty Print', function() {
         head: ''
       })
     })
+
     it('indent <head>', function() {
       expect(this.html).match(/\n {2}<head/)
     })
@@ -22,17 +24,34 @@ describe('Pretty Print', function() {
       expect(this.html).match(/\n {10}<div class="sg-canvas/)
     })
   })
+
   describe('custom indentSize', function() {
     beforeEach(function() {
       this.load("### Hello\n\n    @example\n    div", {
         tabWidth: 4
       })
     })
+
     it('indent .sg-section-hello', function() {
       expect(this.html).match(/<section class="sg-block sg-section-hello/)
     })
     it('indent .sg-canvas', function() {
       expect(this.html).match(/\n {8}<div class="sg-canvas/)
     })
+  })
+})
+
+describe('beautifyHTML | Remove trailing slash self closing tags', function(){
+  it('Remove trailing slash for img tag', function() {
+    let html = beautifyHTML('<img src="foo.bar" alt="Foo image"/>')
+    expect(html).match(/<img src="foo.bar" alt="Foo image" >/)
+  })
+  it("Keep trailing slash for SVG's children tags", function() {
+    let html = beautifyHTML(`
+    <svg>
+      <use xlink:href="../icons.svg#checkmark" href="../icons.svg#checkmark"/>
+    </svg>
+    `)
+    expect(html).match(/<use xlink:href="..\/icons.svg#checkmark" href="..\/icons.svg#checkmark" \/>/)
   })
 })


### PR DESCRIPTION
## Fix

### Don't remove trailing for SVG elements

#58 we've added the removal of all trailing slash, which is not good as SVG elements require a trailing slash.
This PR fix this issue and now trailing slash are only removed from HTML elements and SVG elements are ignored. 