### PR TITLE
[BREAKING] Publish package in peopledoc npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Create a package
+on:
+  release:
+    types: ['created']
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 10 and setup registry
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+          registry-url: https://npm.pkg.github.com/
+      - name: Install deps
+        run: npm ci
+        # env:
+        #   NODE_AUTH_TOKEN: ${{ secrets.GPR_TOKEN }}
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Points to Github NPM registry
+@peopledoc:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Breaking change

### Deploy on Github registry (#63)

Ref(s): [JS-423](https://people-doc.atlassian.net/browse/JS-423)

`styledown` is now deployed on Github registry under `@peopledoc/` scope. 

Change all the import from `styledown` to `@peopledoc/styledown`.  
