### PR TITLE
Release 3.0.0

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@ Styledown API
 Styledown is available as a Node.js package.
 
 ```js
-var Styledown = require('styledown');
+var Styledown = require('@peopledoc/styledown');
 ```
 
 ### Styledown.parse()

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
  * Styledown is available as a Node.js package.
  *
- *     let Styledown = require('styledown');
+ *     let Styledown = require('@peopledoc/styledown');
  */
 
 const Marked = require('marked')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "styledown",
-  "version": "2.1.0",
+  "name": "@peopledoc/styledown",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "styledown",
+  "name": "@peopledoc/styledown",
   "description": "Markdown-based styleguide generator",
   "keywords": [
     "markdown",
     "css",
     "styleguide"
   ],
-  "version": "2.1.0",
+  "version": "3.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/peopledoc/styledown.git"


### PR DESCRIPTION
## Breaking change

### Deploy on Github registry (#63)

Ref(s): [JS-423](https://people-doc.atlassian.net/browse/JS-423)

`styledown` is now deployed on Github registry under `@peopledoc/` scope. 

Change all the import from `styledown` to `@peopledoc/styledown`.  

## Fix

### Don't remove trailing for SVG elements

#58 we've added the removal of all trailing slash, which is not good as SVG elements require a trailing slash.
This PR fix this issue and now trailing slash are only removed from HTML elements and SVG elements are ignored. 

## Build

### Use Github actions as CI instead of CircleCI