### PR TITLE
[FIX] Use vh with max-height 🤦

### DIFF
--- a/assets/styledown.css
+++ b/assets/styledown.css
@@ -136,7 +136,7 @@ code.sg {
  */
 
 .sg-code {
-  max-height: 20vw;
+  max-height: 40vh;
 
   border: solid 1px transparent;
   overflow-x: auto;


### PR DESCRIPTION
`vw` means viewport width so it's not for height.

Also, updated the CSS rule to allow the code's sample box to occupy up to 40% of the window height.